### PR TITLE
Fix for certain third-party SNES controllers which require that the f…

### DIFF
--- a/src/petscii.s
+++ b/src/petscii.s
@@ -53,6 +53,7 @@ handle_petscii:
 	lda #$00
 	sta CIA2_PRB
 	ldx #0
+byte_loop:
 	ldy #7
 loop:
 	clc
@@ -67,10 +68,9 @@ loop:
 	sta CIA2_PRB
 	dey
 	bpl loop
-	ldy #3
 	inx
 	cpx #2
-	bne loop
+	bne byte_loop
 	
 	; 0,  1,    2,    3,      4, 5, 6,   7
 	; 01  02    04    08      10 20 40   80


### PR DESCRIPTION
The current code for SNES controllers connected via the PETSCII Robots Userport Adapter only reads 12 bits from the controller, not the full 16 bits contained in the shift register, because the last 4 bits are unused. The problem with this approach is that certain third-party controllers behave incorrectly when you do not read the full 16 bits, so this pull request modifies the code to read all 16 bits.

This also fixes another bug further down in the code: The code expects the state of the buttons R, L, X, and A in the upper 4 bits of the second byte. Well, they're in the upper 4 bits when you read the full 16 bits, but they are actually in the lower 4 bits when you only read 12 bits. This did not show because the variable ("port_digital + 1") that contains the second byte does not get cleared, so when shifting the 4 bits in during the next pass, the lower 4 bits become the upper 4 bits. So these four buttons seem to work, but the results are actually one frame late.